### PR TITLE
Remove the obligation to use an environment variable to use the APIKEY

### DIFF
--- a/mailersend/base/base.py
+++ b/mailersend/base/base.py
@@ -25,15 +25,15 @@ class NewAPIClient:
         NewAPIClient constructor
         """
 
-        self.api_base = API_BASE
-        self.mailersend_api_key = API_KEY
-        self.headers_auth = f"Bearer {self.mailersend_api_key}"
+        self.api_base = API_BASE if api_base is None else api_base
+        self.mailersend_api_key = API_KEY if mailersend_api_key is None else mailersend_api_key
+        self.headers_auth = f"Bearer {self.mailersend_api_key}" if headers_auth is None else headers_auth
         self.headers_default = {
             "Content-Type": "application/json",
             "X-Requested-With": "XMLHttpRequest",
             "User-Agent": "MailerSend-Client-python-v1",
             "Authorization": f"{self.headers_auth}",
-        }
+        } if headers_default is None else headers_default
 
 
 def generate_config_change_json_body(key, value):


### PR DESCRIPTION
Although the NewAPIClient constructor has parameters defined, these were not used.

The most important part is not having to use an environment variable to indicate the API_KEY. If someone used a KeyManageStorage to store MailerSend's API_KEY, it was necessary for him to Adhoc create an environment variable. 