### PR TITLE
feat(api-key): allow users to define API key in various ways 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,31 @@ $ python -m pip install mailersend
 - Python `pip`
 - An API Key from [mailersend.com](https://www.mailersend.com)
 
+## Authentication
+
+You can use either the `MAILERSEND_API_KEY` environment variable or explicitly
+set a variable in-code.
+
+- Using environment variable
+```python
+from mailersend import domains
+
+mailer = domains.NewDomain()
+
+mailer.get_domains()
+```
+
+- Explicit declaration
+```python
+from mailersend import domains
+
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
+
+mailer.get_domains()
+```
+
 # Usage
 
 ## Email 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ $ python -m pip install mailersend
 - Python > 3.6.1
 - Python `pip`
 - An API Key from [mailersend.com](https://www.mailersend.com)
-- A `MAILERSEND_API_KEY` environment variable
 
 # Usage
 
@@ -90,7 +89,9 @@ $ python -m pip install mailersend
 ```python
 from mailersend import emails
 
-mailer = emails.NewEmail()
+api_key = "API key here"
+
+mailer = emails.NewEmail(api_key)
 
 # define an empty dict to populate with mail values
 mail_body = {}
@@ -130,7 +131,9 @@ mailer.send(mail_body)
 ```python
 from mailersend import emails
 
-mailer = emails.NewEmail()
+api_key = "API key here"
+
+mailer = emails.NewEmail(api_key)
 
 # define an empty dict to populate with mail values
 mail_body = {}
@@ -177,7 +180,9 @@ mailer.send(mail_body)
 ```python
 from mailersend import emails
 
-mailer = emails.NewEmail()
+api_key = "API key here"
+
+mailer = emails.NewEmail(api_key)
 
 # define an empty dict to populate with mail values
 mail_body = {}
@@ -222,7 +227,9 @@ mailer.send(mail_body)
 ```python
 from mailersend import emails
 
-mailer = emails.NewEmail()
+api_key = "API key here"
+
+mailer = emails.NewEmail(api_key)
 
 # define an empty dict to populate with mail values
 mail_body = {}
@@ -274,7 +281,9 @@ mailer.send(mail_body)
 ```python
 from mailersend import emails
 
-mailer = emails.NewEmail()
+api_key = "API key here"
+
+mailer = emails.NewEmail(api_key)
 
 # define an empty dict to populate with mail values
 mail_body = {}
@@ -320,7 +329,9 @@ mailer.send(mail_body)
 from mailersend import emails
 import base64
 
-mailer = emails.NewEmail()
+api_key = "API key here"
+
+mailer = emails.NewEmail(api_key)
 
 # define an empty dict to populate with mail values
 mail_body = {}
@@ -380,7 +391,9 @@ mailer.send(mail_body)
 ```python
 from mailersend import activity
 
-mailer = activity.NewActivity()
+api_key = "API key here"
+
+mailer = activity.NewActivity(api_key)
 
 mailer.get_domain_activity("domain-id")
 ```
@@ -390,7 +403,9 @@ mailer.get_domain_activity("domain-id")
 ```python
 from mailersend import activity
 
-mailer = activity.NewActivity()
+api_key = "API key here"
+
+mailer = activity.NewActivity(api_key)
 
 page = 1
 limit = 20
@@ -420,7 +435,9 @@ mailer.get_domain_activity("domain-id", page, limit, date_from, date_to, events)
 ```python
 from mailersend import analytics
 
-mailer = analytics.NewAnalytics()
+api_key = "API key here"
+
+mailer = analytics.NewAnalytics(api_key)
 
 date_from = 1623073576
 date_to = 1623074976
@@ -441,7 +458,9 @@ mailer.get_activity_by_date(date_from, date_to, events, domain_id, group_by)
 ```python
 from mailersend import analytics
 
-mailer = analytics.NewAnalytics()
+api_key = "API key here"
+
+mailer = analytics.NewAnalytics(api_key)
 
 date_from = 1623073576
 date_to = 1623074976
@@ -457,7 +476,9 @@ mailer.get_opens_by_country(date_from, date_to, domain_id)
 ```python
 from mailersend import analytics
 
-mailer = analytics.NewAnalytics()
+api_key = "API key here"
+
+mailer = analytics.NewAnalytics(api_key)
 
 date_from = 1623073576
 date_to = 1623074976
@@ -473,7 +494,9 @@ mailer.get_opens_by_user_agent(date_from, date_to, domain_id)
 ```python
 from mailersend import analytics
 
-mailer = analytics.NewAnalytics()
+api_key = "API key here"
+
+mailer = analytics.NewAnalytics(api_key)
 
 date_from = 1623073576
 date_to = 1623074976
@@ -491,7 +514,9 @@ mailer.get_opens_by_reading_environment(date_from, date_to, domain_id)
 ```python
 from mailersend import domains
 
-mailer = domains.NewDomain()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
 
 mailer.get_domains()
 ```
@@ -501,7 +526,9 @@ mailer.get_domains()
 ```python
 from mailersend import domains
 
-mailer = domains.NewDomain()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
 
 mailer.get_domain_by_id("domain-id")
 ```
@@ -512,8 +539,10 @@ mailer.get_domain_by_id("domain-id")
 from mailersend import domains
 from mailersend import utils
 
-mailer = domains.NewDomain()
-helper = utils.NewHelper()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
+helper = utils.NewHelper(api_key)
 
 mailer.get_domain_by_id(helper.get_id_by_name("domains","domain-name"))
 ```
@@ -525,7 +554,9 @@ You can find a full list of settings [here](https://developers.mailersend.com/ap
 ```python
 from mailersend import domains
 
-mailer = domains.NewDomain()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
 
 mailer.add_domain("name", "example.com")
 ```
@@ -536,7 +567,9 @@ mailer.add_domain("name", "example.com")
 ```python
 from mailersend import domains
 
-mailer = domains.NewDomain()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
 
 mailer.delete_domain("domain-id")
 ```
@@ -546,7 +579,9 @@ mailer.delete_domain("domain-id")
 ```python
 from mailersend import domains
 
-mailer = domains.NewDomain()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
 
 mailer.get_recipients_for_domain("domain-id")
 ```
@@ -558,7 +593,9 @@ You can find a full list of settings [here](https://developers.mailersend.com/ap
 ```python
 from mailersend import domains
 
-mailer = domains.NewDomain()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
 
 mailer.update_domain_setting("domain-id", "send_paused", True)
 ```
@@ -568,7 +605,9 @@ mailer.update_domain_setting("domain-id", "send_paused", True)
 ```python
 from mailersend import domains
 
-mailer = domains.NewDomain()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
 
 mailer.get_dns_records("domain-id")
 ```
@@ -578,7 +617,9 @@ mailer.get_dns_records("domain-id")
 ```python
 from mailersend import domains
 
-mailer = domains.NewDomain()
+api_key = "API key here"
+
+mailer = domains.NewDomain(api_key)
 
 mailer.verify_domain("domain-id")
 ```
@@ -591,7 +632,9 @@ mailer.verify_domain("domain-id")
 ```python
 from mailersend import messages
 
-mailer = messages.NewMessage()
+api_key = "API key here"
+
+mailer = messages.NewMessage(api_key)
 
 mailer.get_messages()
 ```
@@ -601,7 +644,9 @@ mailer.get_messages()
 ```python
 from mailersend import messages
 
-mailer = messages.NewMessage()
+api_key = "API key here"
+
+mailer = messages.NewMessage(api_key)
 
 mailer.get_message_by_id("message-id")
 ```
@@ -613,7 +658,9 @@ mailer.get_message_by_id("message-id")
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 mailer.get_recipients()
 ```
@@ -623,7 +670,9 @@ mailer.get_recipients()
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 mailer.get_recipient_by_id("recipient-id")
 ```
@@ -633,7 +682,9 @@ mailer.get_recipient_by_id("recipient-id")
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 mailer.delete_recipient("recipient-id")
 ```
@@ -643,7 +694,9 @@ mailer.delete_recipient("recipient-id")
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 mailer.get_recipients_from_blocklist("domain-id")
 ```
@@ -653,7 +706,9 @@ mailer.get_recipients_from_blocklist("domain-id")
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 mailer.get_hard_bounces("domain-id")
 ```
@@ -663,7 +718,9 @@ mailer.get_hard_bounces("domain-id")
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 mailer.get_spam_complaints("domain-id")
 ```
@@ -673,7 +730,9 @@ mailer.get_spam_complaints("domain-id")
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 mailer.get_unsubscribes("domain-id")
 ```
@@ -685,7 +744,9 @@ Using recipients:
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_list = [
     'blocked@client.com'
@@ -699,7 +760,9 @@ Using patterns:
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_patterns = [
     '*@client.com'
@@ -713,7 +776,9 @@ mailer.add_to_blocklist("domain-id", patterns=recipient_patterns)
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_list = [
     "your@client.com"
@@ -727,7 +792,9 @@ mailer.add_hard_bounces("domain-id", recipient_list)
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_list = [
     "your@client.com"
@@ -741,7 +808,9 @@ mailer.add_spam_complaints("domain-id", recipient_list)
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_list = [
     "your@client.com"
@@ -755,7 +824,9 @@ mailer.add_unsubscribes("domain-id", recipient_list)
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_list = [
     "your@client.com"
@@ -769,7 +840,9 @@ mailer.delete_from_blocklist("domain-id", recipient_list)
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_list = [
     "your@client.com"
@@ -783,7 +856,9 @@ mailer.delete_hard_bounces("domain-id", recipient_list)
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_list = [
     "your@client.com"
@@ -797,7 +872,9 @@ mailer.delete_spam_complaints("domain-id", recipient_list)
 ```python
 from mailersend import recipients
 
-mailer = recipients.NewRecipient()
+api_key = "API key here"
+
+mailer = recipients.NewRecipient(api_key)
 
 recipient_list = [
     "your@client.com"
@@ -813,7 +890,9 @@ mailer.delete_unsubscribes("domain-id", recipient_list)
 ```python
 from mailersend import tokens
 
-mailer = tokens.NewToken()
+api_key = "API key here"
+
+mailer = tokens.NewToken(api_key)
 
 scopes = ["email_full", "analytics_read"]
 
@@ -825,7 +904,9 @@ Because of security reasons, we only allow access token appearance once during c
 ```python
 from mailersend import tokens
 
-mailer = tokens.NewToken()
+api_key = "API key here"
+
+mailer = tokens.NewToken(api_key)
 
 scopes = ["email_full", "analytics_read"]
 
@@ -837,7 +918,9 @@ print(mailer.create_token("my-token", scopes))
 ```python
 from mailersend import tokens
 
-mailer = tokens.NewToken()
+api_key = "API key here"
+
+mailer = tokens.NewToken(api_key)
 
 # pause
 mailer.update_token("my-token")
@@ -851,7 +934,9 @@ mailer.update_token("my-token", pause=False)
 ```python
 from mailersend import tokens
 
-mailer = tokens.NewToken()
+api_key = "API key here"
+
+mailer = tokens.NewToken(api_key)
 
 mailer.delete_token("token-id")
 ```
@@ -863,7 +948,9 @@ mailer.delete_token("token-id")
 ```python
 from mailersend import webhooks
 
-mailer = webhooks.NewWebhook()
+api_key = "API key here"
+
+mailer = webhooks.NewWebhook(api_key)
 
 mailer.get_webhooks("domain-id")
 ```
@@ -873,7 +960,9 @@ mailer.get_webhooks("domain-id")
 ```python
 from mailersend import webhooks
 
-mailer = webhooks.NewWebhook()
+api_key = "API key here"
+
+mailer = webhooks.NewWebhook(api_key)
 
 mailer.get_webhook_by_id("webhook-id")
 ```
@@ -883,9 +972,11 @@ mailer.get_webhook_by_id("webhook-id")
 ```python
 from mailersend import webhooks
 
+api_key = "API key here"
+
 webhookEvents = ['activity.sent', 'activity.delivered']
 
-webhook = webhooks.NewWebhook()
+webhook = webhooks.NewWebhook(api_key)
 webhook.set_webhook_url("https://webhooks.mysite.com")
 webhook.set_webhook_name("my first webhook")
 webhook.set_webhook_events(webhookEvents)
@@ -899,9 +990,11 @@ webhook.create_webhook()
 ```python
 from mailersend import webhooks
 
+api_key = "API key here"
+
 webhookEvents = ['activity.sent', 'activity.delivered']
 
-webhook = webhooks.NewWebhook()
+webhook = webhooks.NewWebhook(api_key)
 webhook.set_webhook_url("https://webhooks.mysite.com")
 webhook.set_webhook_name("my first webhook")
 webhook.set_webhook_events(webhookEvents)
@@ -916,7 +1009,9 @@ webhook.create_webhook()
 ```python
 from mailersend import webhooks
 
-webhook = webhooks.NewWebhook()
+api_key = "API key here"
+
+webhook = webhooks.NewWebhook(api_key)
 
 webhook.update_webhook("webhook-id", "name", "a new webhook name")
 ```
@@ -926,7 +1021,9 @@ webhook.update_webhook("webhook-id", "name", "a new webhook name")
 ```python
 from mailersend import webhooks
 
-webhook = webhooks.NewWebhook()
+api_key = "API key here"
+
+webhook = webhooks.NewWebhook(api_key)
 
 webhook.update_webhook("webhook-id", "enabled", False)
 ```
@@ -936,7 +1033,9 @@ webhook.update_webhook("webhook-id", "enabled", False)
 ```python
 from mailersend import webhooks
 
-webhook = webhooks.NewWebhook()
+api_key = "API key here"
+
+webhook = webhooks.NewWebhook(api_key)
 
 webhook.delete_webhook("webhook-id")
 ```

--- a/mailersend/__init__.py
+++ b/mailersend/__init__.py
@@ -3,5 +3,5 @@ MailerSend Official Python DSK
 @maintainer: Alexandros Orfanos (alexandros at remotecompany dot com)
 """
 
-__version_info__ = ("0", "1", "4")
+__version_info__ = ("0", "2", "0")
 __version__ = ".".join(__version_info__)

--- a/mailersend/activity/__init__.py
+++ b/mailersend/activity/__init__.py
@@ -12,17 +12,7 @@ class NewActivity(base.NewAPIClient):
     Instantiates the /activity endpoint object
     """
 
-    def __init__(self):
-        """
-        NewActivity constructor
-        """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+    pass
 
     def get_domain_activity(
         self, domain_id, page=None, limit=None, date_from=None, date_to=None, event=None

--- a/mailersend/analytics/__init__.py
+++ b/mailersend/analytics/__init__.py
@@ -12,17 +12,7 @@ class NewAnalytics(base.NewAPIClient):
     Instantiates the /activity endpoint object
     """
 
-    def __init__(self):
-        """
-        NewAnalytics constructor
-        """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+    pass
 
     def get_activity_by_date(
         self, date_from, date_to, event, domain_id=None, group_by=None

--- a/mailersend/base/base.py
+++ b/mailersend/base/base.py
@@ -16,7 +16,7 @@ class NewAPIClient:
 
     def __init__(
         self,
-        mailersend_api_key,
+        mailersend_api_key=API_KEY,
         api_base=None,
         headers_default=None,
         headers_auth=None,

--- a/mailersend/base/base.py
+++ b/mailersend/base/base.py
@@ -16,17 +16,17 @@ class NewAPIClient:
 
     def __init__(
         self,
+        mailersend_api_key,
         api_base=None,
         headers_default=None,
         headers_auth=None,
-        mailersend_api_key=None,
     ):
         """
         NewAPIClient constructor
         """
 
         self.api_base = API_BASE
-        self.mailersend_api_key = API_KEY
+        self.mailersend_api_key = mailersend_api_key
         self.headers_auth = f"Bearer {self.mailersend_api_key}"
         self.headers_default = {
             "Content-Type": "application/json",

--- a/mailersend/domains/__init__.py
+++ b/mailersend/domains/__init__.py
@@ -12,17 +12,7 @@ class NewDomain(base.NewAPIClient):
     Instantiates the /domains endpoint object
     """
 
-    def __init__(self):
-        """
-        NewDomain constructor
-        """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+    pass
 
     def get_domains(self):
         """
@@ -124,7 +114,7 @@ class NewDomain(base.NewAPIClient):
 
         request = requests.get(
             f"{self.api_base}/domains/{domain_id}/dns-records",
-            headers=self.headers_default
+            headers=self.headers_default,
         )
         return request.text
 
@@ -138,10 +128,6 @@ class NewDomain(base.NewAPIClient):
         """
 
         request = requests.get(
-            f"{self.api_base}/domains/{domain_id}/verify",
-            headers=self.headers_default
+            f"{self.api_base}/domains/{domain_id}/verify", headers=self.headers_default
         )
         return request.text
-
-
-

--- a/mailersend/emails/__init__.py
+++ b/mailersend/emails/__init__.py
@@ -9,20 +9,10 @@ from mailersend.base import base
 
 class NewEmail(base.NewAPIClient):
     """
-    Instantiates the /email endpoint object
+    Send an e-mail
     """
 
-    def __init__(self):
-        """
-        NewEmail constructor
-        """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+    pass
 
     def set_mail_from(self, mail_from, message):
         """

--- a/mailersend/messages/__init__.py
+++ b/mailersend/messages/__init__.py
@@ -12,17 +12,7 @@ class NewMessage(base.NewAPIClient):
     Instantiates the /messages endpoint object
     """
 
-    def __init__(self):
-        """
-        NewMessage constructor
-        """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+    pass
 
     def get_message_by_id(self, message_id):
         """

--- a/mailersend/recipients/__init__.py
+++ b/mailersend/recipients/__init__.py
@@ -12,17 +12,7 @@ class NewRecipient(base.NewAPIClient):
     Instantiates the /recipients endpoint object
     """
 
-    def __init__(self):
-        """
-        NewRecipient constructor
-        """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+    pass
 
     def get_recipients(self):
         """

--- a/mailersend/templates/__init__.py
+++ b/mailersend/templates/__init__.py
@@ -12,17 +12,7 @@ class NewTemplate(base.NewAPIClient):
     Instantiates the /templates endpoint object
     """
 
-    def __init__(self):
-        """
-        NewTemplate constructor
-        """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+    pass
 
     def get_templates(self):
         """

--- a/mailersend/tokens/__init__.py
+++ b/mailersend/tokens/__init__.py
@@ -12,17 +12,7 @@ class NewToken(base.NewAPIClient):
     Instantiates the /tokens endpoint object
     """
 
-    def __init__(self):
-        """
-        NewToken constructor
-        """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+    pass
 
     def create_token(self, token_name, token_scopes):
         """

--- a/mailersend/utils/__init__.py
+++ b/mailersend/utils/__init__.py
@@ -15,13 +15,7 @@ class NewHelper(base.NewAPIClient):
         """
         NewHelper constructor
         """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+        pass
 
     def get_id_by_name(self, category, name):
         """

--- a/mailersend/webhooks/__init__.py
+++ b/mailersend/webhooks/__init__.py
@@ -18,13 +18,7 @@ class NewWebhook(base.NewAPIClient):
         """
         NewWebhook constructor
         """
-        baseobj = base.NewAPIClient()
-        super().__init__(
-            baseobj.api_base,
-            baseobj.headers_default,
-            baseobj.headers_auth,
-            baseobj.mailersend_api_key,
-        )
+        pass
 
     def get_webhooks(self, domain_id):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mailersend"
-version = "0.1.4"
+version = "0.2.0"
 description = "The official MailerSend Python SDK"
 authors = ["Alex Orfanos <alexandros@mailerlite.com>"]
 


### PR DESCRIPTION
Users can now define an API key by setting it as a positional argument to base object creation. E.g., for domains:

```python
from mailersend import domains

api_key = "Your API key"

mailer = domains.NewDomain(api_key)

mailer.get_domains()
```

If no API key is set in-code, we fallback to the `MAILERSEND_API_KEY` environment variable.

```shell
export MAILERSEND_API_KEY="eyJ...."
```

```python
from mailersend import domains

mailer = domains.NewDomain()

mailer.get_domains()
```