### PR TITLE
Fix NewHelper attribute error

### DIFF
--- a/mailersend/utils/__init__.py
+++ b/mailersend/utils/__init__.py
@@ -11,12 +11,6 @@ class NewHelper(base.NewAPIClient):
     NewHelper extends base.NewAPIClient to inherit connection details
     """
 
-    def __init__(self):
-        """
-        NewHelper constructor
-        """
-        pass
-
     def get_id_by_name(self, category, name):
         """
         Returns an ID given a category and item name from the MailerSend API


### PR DESCRIPTION
- Remove empty init class in `NewHelper` to use inherited properties of `NewAPIClient` like `self.api_base` etc
