### PR TITLE
Add missing webhook events

### DIFF
--- a/mailersend/builders/webhooks.py
+++ b/mailersend/builders/webhooks.py
@@ -122,6 +122,7 @@ class WebhooksBuilder:
             "activity.delivered",
             "activity.soft_bounced",
             "activity.hard_bounced",
+            "activity.deferred",
             "activity.opened",
             "activity.opened_unique",
             "activity.clicked",
@@ -154,6 +155,20 @@ class WebhooksBuilder:
             self.add_event(event)
         return self
 
+    def recipient_events(self) -> "WebhooksBuilder":
+        """Add all recipient events to the webhook.
+
+        Returns:
+            WebhooksBuilder: Self for method chaining
+        """
+        recipient_events = [
+            "recipient.on_hold_added",
+            "recipient.on_hold_removed",
+        ]
+        for event in recipient_events:
+            self.add_event(event)
+        return self
+
     def all_events(self) -> "WebhooksBuilder":
         """Add all available events to the webhook.
 
@@ -162,6 +177,7 @@ class WebhooksBuilder:
         """
         self.activity_events()
         self.system_events()
+        self.recipient_events()
         return self
 
     def build_webhooks_list_request(self) -> WebhooksListRequest:

--- a/tests/unit/test_webhooks_builder.py
+++ b/tests/unit/test_webhooks_builder.py
@@ -100,6 +100,7 @@ class TestWebhooksBuilder:
             "activity.delivered",
             "activity.soft_bounced",
             "activity.hard_bounced",
+            "activity.deferred",
             "activity.opened",
             "activity.opened_unique",
             "activity.clicked",
@@ -128,6 +129,18 @@ class TestWebhooksBuilder:
         ]
         assert builder._events == expected_events
 
+    def test_recipient_events(self):
+        """Test adding all recipient events."""
+        builder = WebhooksBuilder()
+        result = builder.recipient_events()
+        assert result is builder  # Fluent interface
+
+        expected_events = [
+            "recipient.on_hold_added",
+            "recipient.on_hold_removed",
+        ]
+        assert builder._events == expected_events
+
     def test_all_events(self):
         """Test adding all available events."""
         builder = WebhooksBuilder()
@@ -139,6 +152,7 @@ class TestWebhooksBuilder:
             "activity.delivered",
             "activity.soft_bounced",
             "activity.hard_bounced",
+            "activity.deferred",
             "activity.opened",
             "activity.opened_unique",
             "activity.clicked",
@@ -157,7 +171,11 @@ class TestWebhooksBuilder:
             "email_list.verified",
             "bulk_email.completed",
         ]
-        expected_all_events = expected_activity_events + expected_system_events
+        expected_recipient_events = [
+            "recipient.on_hold_added",
+            "recipient.on_hold_removed",
+        ]
+        expected_all_events = expected_activity_events + expected_system_events + expected_recipient_events
         assert builder._events == expected_all_events
 
     def test_method_chaining(self):


### PR DESCRIPTION
resolves [MSD-10396](https://linear.app/mailerlite/issue/MSD-10396/on-hold-webhook)

### Changelist
- [ ] Added below events to webhook

```
DEFERRED — "activity.deferred"
RECIPIENT_ON_HOLD_ADDED — "recipient.on_hold_added"
RECIPIENT_ON_HOLD_REMOVED — "recipient.on_hold_removed"
```