### PR TITLE
Add optional language field to email send

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,21 @@ email = (EmailBuilder()
 response = ms.emails.send(email)
 ```
 
+You can also set a `language` code for a template-based email. It is
+only meaningful with a template and is ignored for raw html/text sends.
+Supported codes: `de`, `en`, `es`, `fr`, `it`, `lt`, `nl`, `pl`, `pt-BR`.
+
+```python
+email = (EmailBuilder()
+         .from_email("sender@domain.com", "Your Name")
+         .to_many([{"email": "recipient@domain.com", "name": "Recipient"}])
+         .template("template-id")
+         .language("de")
+         .build())
+
+response = ms.emails.send(email)
+```
+
 ### Personalization
 
 ```python

--- a/mailersend/builders/email.py
+++ b/mailersend/builders/email.py
@@ -69,6 +69,7 @@ class EmailBuilder:
         self._html: Optional[str] = None
         self._text: Optional[str] = None
         self._template_id: Optional[str] = None
+        self._language: Optional[str] = None
         self._attachments: List[EmailAttachment] = []
         self._tags: List[str] = []
         self._personalization: List[EmailPersonalization] = []
@@ -345,6 +346,23 @@ class EmailBuilder:
             EmailBuilder instance for chaining
         """
         self._template_id = template_id
+        return self
+
+    def language(self, language: str) -> "EmailBuilder":
+        """
+        Set the language for the email content.
+
+        Only meaningful when sending with a template; ignored for raw
+        html/text sends. Supported codes: de, en, es, fr, it, lt,
+        nl, pl, pt-BR.
+
+        Args:
+            language: Language code (e.g. "de", "fr", "pt-BR")
+
+        Returns:
+            EmailBuilder instance for chaining
+        """
+        self._language = language
         return self
 
     def attach_file(
@@ -680,6 +698,8 @@ class EmailBuilder:
             data["text"] = self._text
         if self._template_id:
             data["template_id"] = self._template_id
+        if self._language:
+            data["language"] = self._language
         if self._attachments:
             data["attachments"] = self._attachments
         if self._tags:
@@ -734,6 +754,7 @@ class EmailBuilder:
         new_builder._html = self._html
         new_builder._text = self._text
         new_builder._template_id = self._template_id
+        new_builder._language = self._language
         new_builder._attachments = self._attachments.copy()
         new_builder._tags = self._tags.copy()
         new_builder._personalization = self._personalization.copy()

--- a/mailersend/models/email.py
+++ b/mailersend/models/email.py
@@ -62,6 +62,7 @@ class EmailRequest(BaseModel):
     text: Optional[str] = None
     html: Optional[str] = None
     template_id: Optional[str] = None
+    language: Optional[str] = None
     attachments: Optional[List[EmailAttachment]] = None
     tags: Optional[List[str]] = None
     personalization: Optional[List[EmailPersonalization]] = None

--- a/tests/unit/test_email_builder.py
+++ b/tests/unit/test_email_builder.py
@@ -300,6 +300,35 @@ class TestEmailBuilder:
 
         assert email.template_id == "template-123"
 
+    def test_language_method(self):
+        """Test language is set when provided"""
+        email = (
+            EmailBuilder()
+            .from_email("sender@example.com")
+            .to("recipient@example.com")
+            .subject("Language Test")
+            .template("template-123")
+            .language("de")
+            .build()
+        )
+
+        assert email.language == "de"
+        assert "language" in email.model_dump(by_alias=True, exclude_none=True)
+
+    def test_language_omitted_when_not_set(self):
+        """Test language defaults to None and is omitted from the payload"""
+        email = (
+            EmailBuilder()
+            .from_email("sender@example.com")
+            .to("recipient@example.com")
+            .subject("No Language Test")
+            .template("template-123")
+            .build()
+        )
+
+        assert email.language is None
+        assert "language" not in email.model_dump(by_alias=True, exclude_none=True)
+
     def test_attach_file(self):
         """Test file attachment"""
         file_content = b"This is test file content"


### PR DESCRIPTION
resolves [MSD-14489](https://linear.app/mailerlite/issue/MSD-14489/document-language-field-on-email-send-api-and-sdks)

Surfaces the new optional `language` field from the API's template-translations feature (MSD-14341) in the SDK.

### Changelist
- Add an optional `language` parameter to the email-send builder/params (e.g. `setLanguage("de")` / `.language("de")`), mirroring how `template_id` is handled.
- Include `language` in the request payload only when set; both single and bulk sends covered.
- README: add a short template + language example.