### PR TITLE
Bump version to 2.0.4 and make constants.py the single source of truth

### DIFF
--- a/mailersend/__init__.py
+++ b/mailersend/__init__.py
@@ -67,9 +67,11 @@ from .exceptions import (
     ValidationError,
 )
 
-__version__ = "2.0.0"
+from .constants import __version__
 
 __all__ = [
+    # Package metadata
+    "__version__",
     # Core clients
     "MailerSendClient",
     "AsyncMailerSendClient",

--- a/mailersend/constants.py
+++ b/mailersend/constants.py
@@ -7,7 +7,7 @@ DEFAULT_TIMEOUT = 30  # seconds
 
 # Package info for user agent
 PACKAGE_NAME = "mailersend-python"
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 USER_AGENT = (
     f"{PACKAGE_NAME}/{__version__} "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mailersend"
-version = "2.0.3"
+dynamic = ["version"]
 description = "The official MailerLite Python SDK"
 authors = [{name = "MailerLite", email = "tech@mailerlite.com"}]
 requires-python = ">=3.10"
@@ -30,6 +30,9 @@ asyncio_default_fixture_loop_scope = "function"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "mailersend/constants.py"
 
 [tool.semantic_release]
 branch = "main"

--- a/uv.lock
+++ b/uv.lock
@@ -516,7 +516,6 @@ wheels = [
 
 [[package]]
 name = "mailersend"
-version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The project currently has version drift:

* `__init__.py` reports version `2.0.0`.
* `constants.py` and `pyproject.toml` report version `2.0.3`.
* GitHub Releases already contains a `2.0.4` release.

This mismatch caused the PyPI publishing workflow to fail:

https://github.com/mailersend/mailersend-python/actions/runs/29732208568/job/88319075241

This PR makes the version in `constants.py` the single source of truth:

* `__init__.py` now imports the version from `constants.py`.
* `pyproject.toml` now uses `dynamic = ["version"]`.

More information about this approach:

* https://packaging.python.org/en/latest/discussions/single-source-version/#single-source-version
* https://hatch.pypa.io/1.17/version/

## Follow-up required

Merging this PR alone will not fix the existing PyPI release. A maintainer will also need to update the Git tag and rerun the `build-n-publish` workflow:

```bash
git tag -f v2.0.4 <bump-commit-sha>
git push --force origin v2.0.4
```

Alternatively, a new `v2.0.5` release can be created if force-updating the existing tag is not desirable.